### PR TITLE
Use poetry-core instead of poetry as build backend to fix build problem

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,5 +28,5 @@ sphinx-rtd-theme = "^0.4.3"
 twine = "^3.1.1"
 
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.1.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
After poetry version 1.1.0, it's not necessary to use the full poetry to build packages. Using the smaller poetry-core is the preferred way. This also fix a build dependency problem on Arch Linux.

Hi, I'm making a package of this on Arch Linux. But it fails to build with the `python-poetry` package, and builds successfully with the `python-poetry-core` package. So I make this simple fix. I think it won't break anything, please consider it.

FYI, https://github.com/python-poetry/poetry-core?tab=readme-ov-file#why-is-this-required